### PR TITLE
docs(brain): align Consolidate docstring with the 8-stage pipeline

### DIFF
--- a/internal/brain/consolidate.go
+++ b/internal/brain/consolidate.go
@@ -36,7 +36,7 @@ type ConsolidationResult struct {
 	Errors                     []string      `json:"errors,omitempty"`
 }
 
-// Consolidate runs the full 3-stage consolidation pipeline for a namespace.
+// Consolidate runs the full 8-stage consolidation pipeline for a namespace.
 func (b *Brain) Consolidate(ctx context.Context, namespaceSlug string) (ConsolidationResult, error) {
 	if err := validatePath(namespaceSlug); err != nil {
 		return ConsolidationResult{}, err
@@ -48,10 +48,16 @@ func (b *Brain) Consolidate(ctx context.Context, namespaceSlug string) (Consolid
 	return b.ConsolidateByID(ctx, nsID)
 }
 
-// ConsolidateByID runs the full 3-stage consolidation pipeline for a namespace by ID.
-// 1. Episodes -> Facts (cluster + synthesize)
-// 2. Facts -> Relationships (extract entity edges)
-// 3. Facts + Relationships -> Patterns (extract abstractions)
+// ConsolidateByID runs the full 8-stage consolidation pipeline for a namespace by ID.
+// Stages run in execution order:
+// 1. Episodes -> Facts                    (cluster + synthesize, with inline contradiction detection)
+// 2. Facts -> Relationships               (extract entity edges)
+// 3. Facts -> Causal Links                (cause/effect relationships)
+// 4. Goal Progress Inference              (annotate goals from new facts)
+// 5. Failure Pattern Detection            (recurring failures across episodes)
+// 6. Facts + Relationships -> Patterns    (extract abstractions)
+// 7. Hypothesis Evidence Scanning         (auto-confirm/reject pending hypotheses)
+// 8. Confidence Decay                     (pure-SQL, no LLM)
 func (b *Brain) ConsolidateByID(ctx context.Context, nsID int64) (ConsolidationResult, error) {
 	start := time.Now()
 


### PR DESCRIPTION
The README correctly describes the consolidation pipeline as 8-stage, and commit `bfa8586` updated it for the post-`13345ae` shape (goal progress, failure patterns, hypothesis evidence). The `Consolidate` and `ConsolidateByID` docstrings in `internal/brain/consolidate.go` still claim "3-stage" and list only the original three stages, so a reader of `brain.go` sees a much smaller pipeline than the function actually runs.

`ConsolidateByID` calls (and surfaces fields in `ConsolidationResult` for):

- Stage 1 — `consolidateEpisodesToFacts` (with inline contradiction detection)
- Stage 2 — `consolidateFactsToRelationships`
- Stage 3.5 — `consolidateFactsToCausalLinks`
- Stage 6 — `consolidateGoalProgress`
- Stage 7 — `consolidateFailurePatterns`
- Stage 3 — `consolidateFactsToPatterns`
- Stage 8 — `consolidateHypothesisEvidence`
- Stage 5 — `decayConfidence` (pure-SQL, no LLM)

The diff updates both docstrings to "8-stage" and enumerates the stages in their actual execution order with one-line descriptions. Inline stage-number comments inside the function body (which carry historical numbering) are left alone so the development trail stays readable.

No code change. `gofmt -l` clean.