### PR TITLE
fix(security): escape LIKE wildcards in namespace path resolution

### DIFF
--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -146,6 +146,14 @@ func splitPath(path string) []string {
 	return strings.Split(path, "/")
 }
 
+// escapeLikePattern escapes the PostgreSQL LIKE meta-characters so the input
+// is matched as a literal. Use with `ESCAPE '\'` in the query.
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+func escapeLikePattern(s string) string {
+	return likeEscaper.Replace(s)
+}
+
 // resolveNamespaceID returns the namespace ID for an exact path.
 // Returns ErrNamespaceNotFound if no matching namespace exists.
 func (b *Brain) resolveNamespaceID(ctx context.Context, path string) (int64, error) {
@@ -216,9 +224,12 @@ func (b *Brain) resolveNamespaceIDWithDescendants(ctx context.Context, path stri
 		return ids, rows.Err()
 	}
 
+	// Slug segments allow `_` (see pathSegmentRe), which is a LIKE wildcard
+	// in PostgreSQL. Escape it so `/foo_bar` only matches its own descendants,
+	// not `/fooXbar/...` for any X.
 	rows, err := b.pool.Query(ctx,
-		"SELECT id FROM namespaces WHERE slug = $1 OR slug LIKE $2",
-		path, path+"/%",
+		`SELECT id FROM namespaces WHERE slug = $1 OR slug LIKE $2 ESCAPE '\'`,
+		path, escapeLikePattern(path)+"/%",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("resolve namespace descendants: %w", err)


### PR DESCRIPTION
## Security Vulnerability Report

**Type:** LIKE wildcard injection / namespace data bleed (CWE-89 family)
**Severity:** low
**Location:** `internal/brain/brain.go:220` (`resolveNamespaceIDWithDescendants`)

### Description

`pathSegmentRe` in `internal/brain/brain.go:24` is `^[a-z0-9][a-z0-9_-]{0,63}$`. Slugs may legitimately contain `_`. The descendant lookup builds a `LIKE` pattern out of that slug:

```go
rows, err := b.pool.Query(ctx,
    "SELECT id FROM namespaces WHERE slug = $1 OR slug LIKE $2",
    path, path+"/%",
)
```

In PostgreSQL `LIKE`, `_` matches **any single character**. So:

```
Path: /foo_bar
LIKE: '/foo_bar/%'
  matches  /foo_bar/anything   (intended)
  matches  /fooXbar/anything   (NOT intended -- X = any char)
```

Every operation that resolves descendants is affected: `recall`, `query_facts`, `query_relationships`, `list_failures`, `list_goals`, `list_hypotheses`, `list_contradictions`, `list_causal_links`, `consolidate`, etc.

### Reproduction

```bash
stash namespace create /foo_bar --name "intended"
stash namespace create /fooXbar --name "unrelated"
stash remember --namespace /fooXbar/note "secret from unrelated namespace"
stash recall --namespaces /foo_bar "secret"
# returns the /fooXbar/note entry
```

### Impact

Namespace separation is the only logical access boundary in stash — when an agent (or a wrapper that brokers access by namespace) is told to scope to one namespace, it gets memories, facts, relationships, etc. from unrelated namespaces it should not see. Limited blast radius because `%` is not allowed by the slug regex (so the leak is bounded to single-character substitutions within the same path length and structure), but the exposure is real and unintended.

### Fix

Two-line change: escape `_`, `%`, and `\` in the path before building the `LIKE` pattern, and add `ESCAPE '\'` to the query. No behavioral change for slugs that don't contain `_`. Adds a small `escapeLikePattern` helper alongside `splitPath`.

```go
rows, err := b.pool.Query(ctx,
    `SELECT id FROM namespaces WHERE slug = $1 OR slug LIKE $2 ESCAPE '\'`,
    path, escapeLikePattern(path)+"/%",
)
```

---
Found by [Aeon](https://github.com/aaronjmars/aeon-aaron) — automated security scanner.
