### PR TITLE
fix: pattern stage silently drops all output due to && vs || in fallback logic

### DIFF
--- a/internal/brain/consolidate.go
+++ b/internal/brain/consolidate.go
@@ -648,7 +648,7 @@ func (b *Brain) consolidateToPatterns(ctx context.Context, nsID int64, cp *model
 		// If no source IDs provided, use all facts/rels as sources
 		sourceFactIDs := p.SourceFactIDs
 		sourceRelIDs := p.SourceRelIDs
-		if len(sourceFactIDs) == 0 && len(sourceRelIDs) == 0 {
+		if len(sourceFactIDs) == 0 || len(sourceRelIDs) == 0 {
 			sourceFactIDs = make([]int64, len(facts))
 			for i, f := range facts {
 				sourceFactIDs[i] = f.ID


### PR DESCRIPTION
## What this fixes

The Pattern stage (stage 5) of the consolidation pipeline was silently discarding every pattern it generated. No patterns have ever been successfully written to the database.

## Root cause

In `internal/brain/consolidate.go` (~line 651), the fallback that populates `sourceFactIDs` and `sourceRelIDs` used `&&` instead of `||`:

```go
// Before (buggy)
if len(sourceFactIDs) == 0 && len(sourceRelIDs) == 0 {
```

This means the fallback only ran when **both** slices were empty. If the LLM returned fact IDs but no relationship IDs (or vice versa), one slice stayed `nil`. The INSERT then passed `NULL` for that column — which overrides the column default of `'{}'::bigint[]` and fails the `NOT NULL` constraint.

## The fix

```go
// After (fixed)
if len(sourceFactIDs) == 0 || len(sourceRelIDs) == 0 {
```

One character. Now the fallback populates whichever slice is missing, so neither is ever `nil` when passed to the INSERT.

## How it was caught

Found by running the Stash autonomous learning loop against a live instance and observing these errors in the Postgres logs:

```
ERROR: null value in column "source_rel_ids" of relation "patterns" violates not-null constraint
DETAIL: Failing row contains (..., {25,33}, null, 0.53, ...)
STATEMENT: INSERT INTO patterns (namespace_id, content, confidence, source_fact_ids, source_rel_ids, coherence_score)
           VALUES ($1, $2, $3, $4, $5, $6)
```

## Why it was hard to notice

- `consolidate()` reports `patterns_found: 1` even when the INSERT failed, so the error is invisible to the agent
- The error is caught by the `errs` collector and logged, but not surfaced through the MCP tool return in a way that would alert a user
- The checkpoint guard (`len(errs) == 0`) correctly blocks advancement, so Stash keeps retrying — but keeps failing until this is fixed

## Confirmed against
- `\d patterns` in psql shows both columns are `NOT NULL` with default `'{}'::bigint[]` — the schema is fine, the bug is purely in the Go code
- Reproduced on latest `main` via `docker compose up` on Windows

## Context
Caught by running the autonomous learning loop from the Stash docs against a live instance — the loop noticed the Postgres errors in the container logs after two sessions