### PR TITLE
docs: post-install guide + fix MCP copy buttons (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ docker compose up
 
 That's it. Postgres + pgvector, migrations, MCP server with background consolidation — all in one command.
 
+**Next:** [Getting Started guide](docs/GETTING_STARTED.md) — connect your MCP client, run `init` / `remember` / `recall`, and verify everything works.
+
 ## MCP Client Setup
 
 After `docker compose up`, Stash exposes an MCP server over SSE at:

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,102 @@
+# Getting Started with Stash
+
+You ran `docker compose up`. Here's what to do next.
+
+## 1. Verify Stash is running
+
+```bash
+docker compose ps
+docker compose logs stash | tail -20
+```
+
+You should see the MCP server listening on port **8080**. The SSE endpoint is:
+
+```
+http://localhost:8080/sse
+```
+
+Quick check (expects HTTP 200 or SSE handshake):
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/sse
+```
+
+## 2. Connect your MCP client
+
+Point any MCP-over-SSE client at `http://localhost:8080/sse`.
+
+**Cursor** — create or edit `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "stash": {
+      "url": "http://localhost:8080/sse"
+    }
+  }
+}
+```
+
+Restart Cursor (or reload MCP). Stash should appear in your MCP tool list.
+
+See [README MCP Client Setup](../README.md#mcp-client-setup) for Claude Desktop, Windsurf, and OpenCode configs.
+
+## 3. First session workflow
+
+Once connected, ask your agent to use Stash tools in this order:
+
+| Step | MCP tool | What it does |
+|------|----------|--------------|
+| 1 | `init` | Creates `/self` namespace scaffold (capabilities, limits, preferences) |
+| 2 | `remember` | Store an episode or fact ("User prefers Python", "Project uses Postgres") |
+| 3 | `recall` | Semantic search over what you stored |
+| 4 | `consolidate` | Run the pipeline that turns episodes into structured facts |
+
+Example prompts to your agent:
+
+- *"Call Stash `init` to set up memory namespaces."*
+- *"Use Stash `remember` to store: this project uses Stash on port 8080 with pgvector."*
+- *"Use Stash `recall` to find what you know about this project's stack."*
+- *"Run Stash `consolidate` to process recent episodes into facts."*
+
+## 4. Background consolidation
+
+When started with `mcp serve --with-consolidation` (the Docker Compose default), Stash consolidates in the background. You can also trigger manually via the `consolidate` MCP tool or CLI:
+
+```bash
+docker compose exec stash /stash consolidate run
+```
+
+## 5. Configuration checklist
+
+If tools fail, check `.env`:
+
+| Variable | Purpose |
+|----------|---------|
+| `STASH_OPENAI_API_KEY` | Embeddings + reasoner (OpenAI, OpenRouter, or compatible) |
+| `STASH_OPENAI_BASE_URL` | API base URL |
+| `STASH_EMBEDDING_MODEL` | Must match `STASH_VECTOR_DIM` (1536 for `text-embedding-3-small`) |
+| `STASH_REASONER_MODEL` | Model used during consolidation |
+
+## Troubleshooting
+
+**MCP client can't connect**
+
+- Confirm `docker compose up` finished and port 8080 is not in use elsewhere.
+- Use `http://localhost:8080/sse` (not `https`) for local Docker.
+
+**Empty recall results**
+
+- Run `init` first, then `remember`, then `recall`.
+- Embeddings require a valid API key in `.env`.
+
+**Consolidation does nothing**
+
+- Needs episodes via `remember` first.
+- Check logs: `docker compose logs stash`.
+
+## Next steps
+
+- Explore namespaces: `list_namespaces`, `create_namespace`
+- Track goals and failures: `create_goal`, `create_failure`
+- Full tool list: see the [docs site MCP section](https://alash3al.github.io/stash/#mcp)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1536,6 +1536,18 @@
     font-size: 11px;
     color: var(--text-muted);
   }
+  .integration-copy {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 11px;
+    background: var(--amber);
+    color: #000;
+    border: none;
+    padding: 4px 10px;
+    cursor: pointer;
+    font-weight: 500;
+    flex-shrink: 0;
+  }
+  .integration-copy:hover { background: #fff; }
   .integration-code {
     font-family: 'IBM Plex Mono', monospace;
     font-size: 12px;
@@ -2138,6 +2150,10 @@
             <div class="qs-step-num">3</div>
             <div class="qs-step-text">Run <code>docker compose up</code> — that's it. Stash is live.</div>
           </div>
+          <div class="qs-step">
+            <div class="qs-step-num">4</div>
+            <div class="qs-step-text">Connect your MCP client (see below) — then run <code>init</code> → <code>remember</code> → <code>recall</code>. <a href="GETTING_STARTED.md" style="color:var(--amber)">Full walkthrough →</a></div>
+          </div>
         </div>
       </div>
       <div class="qs-right">
@@ -2190,7 +2206,7 @@
       <div class="mcp-url-label">MCP Server URL</div>
       <div class="mcp-url-box">
         <span class="mcp-url-text">http://localhost:8080/sse</span>
-        <button class="mcp-url-copy" onclick="navigator.clipboard.writeText('http://localhost:8080/sse');this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',2000)">Copy</button>
+        <button class="mcp-url-copy" type="button" data-copy="http://localhost:8080/sse">Copy</button>
       </div>
       <div class="mcp-url-sub">Stash is already running after <code>docker compose up</code> — just copy the URL above into your agent.</div>
     </div>
@@ -2217,9 +2233,10 @@
       <div class="integration-card">
         <div class="integration-header">
           <span class="integration-name">Cursor</span>
-          <span class="integration-path">~/.cursor/mcp.json</span>
+          <button class="integration-copy" type="button" data-copy-target="cfg-cursor">Copy config</button>
         </div>
-        <pre class="integration-code">{
+        <div class="integration-path">~/.cursor/mcp.json</div>
+        <pre class="integration-code" id="cfg-cursor">{
   "mcpServers": {
     "stash": {
       "url": "http://localhost:8080/sse"
@@ -2231,9 +2248,10 @@
       <div class="integration-card">
         <div class="integration-header">
           <span class="integration-name">Claude Desktop</span>
-          <span class="integration-path">claude_desktop_config.json</span>
+          <button class="integration-copy" type="button" data-copy-target="cfg-claude">Copy config</button>
         </div>
-        <pre class="integration-code">{
+        <div class="integration-path">claude_desktop_config.json</div>
+        <pre class="integration-code" id="cfg-claude">{
   "mcpServers": {
     "stash": {
       "url": "http://localhost:8080/sse"
@@ -2245,9 +2263,10 @@
       <div class="integration-card">
         <div class="integration-header">
           <span class="integration-name">OpenCode</span>
-          <span class="integration-path">~/.config/opencode/config.json</span>
+          <button class="integration-copy" type="button" data-copy-target="cfg-opencode">Copy config</button>
         </div>
-        <pre class="integration-code">{
+        <div class="integration-path">~/.config/opencode/config.json</div>
+        <pre class="integration-code" id="cfg-opencode">{
   "mcp": {
     "stash": {
       "type": "remote",
@@ -2261,9 +2280,10 @@
       <div class="integration-card">
         <div class="integration-header">
           <span class="integration-name">Windsurf</span>
-          <span class="integration-path">~/.codeium/windsurf/mcp_config.json</span>
+          <button class="integration-copy" type="button" data-copy-target="cfg-windsurf">Copy config</button>
         </div>
-        <pre class="integration-code">{
+        <div class="integration-path">~/.codeium/windsurf/mcp_config.json</div>
+        <pre class="integration-code" id="cfg-windsurf">{
   "mcpServers": {
     "stash": {
       "url": "http://localhost:8080/sse"
@@ -2916,6 +2936,49 @@ document.getElementById('usage-restart').addEventListener('click', () => {
   runUsageDemo();
 });
 
+function fallbackCopy(text, btn) {
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.style.position = 'fixed';
+  ta.style.left = '-9999px';
+  document.body.appendChild(ta);
+  ta.select();
+  try {
+    document.execCommand('copy');
+    const orig = btn.textContent;
+    btn.textContent = 'Copied!';
+    setTimeout(() => { btn.textContent = orig; }, 1500);
+  } catch (e) {
+    btn.textContent = 'Failed';
+    setTimeout(() => { btn.textContent = 'Copy'; }, 1500);
+  }
+  document.body.removeChild(ta);
+}
+
+function copyToClipboard(text, btn) {
+  if (navigator.clipboard && window.isSecureContext) {
+    navigator.clipboard.writeText(text).then(() => {
+      const orig = btn.textContent;
+      btn.textContent = 'Copied!';
+      setTimeout(() => { btn.textContent = orig; }, 1500);
+    }).catch(() => fallbackCopy(text, btn));
+  } else {
+    fallbackCopy(text, btn);
+  }
+}
+
+document.querySelectorAll('[data-copy]').forEach(btn => {
+  btn.addEventListener('click', () => {
+    copyToClipboard(btn.getAttribute('data-copy'), btn);
+  });
+});
+
+document.querySelectorAll('[data-copy-target]').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const target = document.getElementById(btn.getAttribute('data-copy-target'));
+    if (target) copyToClipboard(target.textContent.trim(), btn);
+  });
+});
 
 </script>
 </body>


### PR DESCRIPTION
## Summary

Fixes #6.

- Adds **`docs/GETTING_STARTED.md`** — what to do after `docker compose up`: verify the MCP server, connect Cursor/Claude Desktop/etc., run `init` → `remember` → `recall` → `consolidate`, and basic troubleshooting.
- Links the guide from **README** and the docs landing page (new quickstart step 4).
- Fixes **MCP copy buttons** on the docs site: replaces broken inline `onclick` handlers with `data-copy` / `data-copy-target` attributes and shared clipboard JS (Clipboard API + `execCommand` fallback). Adds per-client **Copy config** buttons on the integration cards.

## Test plan

- [ ] Open `docs/index.html` locally (or GitHub Pages preview)
- [ ] Click **Copy** on the MCP URL hero — should show "Copied!"
- [ ] Click **Copy config** on each integration card — JSON should land on clipboard
- [ ] Follow `docs/GETTING_STARTED.md` against a running `docker compose up` stack


Made with [Cursor](https://cursor.com)