### PR TITLE
docs: Ollama local-first setup + pipeline stage count alignment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,13 @@ STASH_EMBEDDING_MODEL=text-embedding-3-small
 # OpenRouter: openai/gpt-4o-mini, google/gemma-4-26b-a4b-it
 STASH_REASONER_MODEL=gpt-4o-mini
 
+# --- Ollama (fully local — see docs/LOCAL_OLLAMA.md) ---
+# STASH_OPENAI_API_KEY=ollama
+# STASH_OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+# STASH_EMBEDDING_MODEL=nomic-embed-text
+# STASH_REASONER_MODEL=qwen2.5:3b
+# STASH_VECTOR_DIM=768
+
 # Memory Configuration
 # Time-to-live for context (working memory windows)
 # Format: 1h, 30m, 2h30m, etc.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ That's it. Postgres + pgvector, migrations, MCP server with background consolida
 
 **Next:** [Getting Started guide](docs/GETTING_STARTED.md) — connect your MCP client, run `init` / `remember` / `recall`, and verify everything works.
 
+**Fully local (no cloud API):** [Ollama setup guide](docs/LOCAL_OLLAMA.md) — host Ollama + Docker Compose, private embeddings and reasoner.
+
 ## MCP Client Setup
 
 After `docker compose up`, Stash exposes an MCP server over SSE at:
@@ -81,7 +83,7 @@ Works with any agent that supports MCP over SSE — Claude Desktop, Cursor, Wind
 
 Stash is a cognitive layer between your AI agent and the world. Episodes become facts. Facts become relationships. Relationships become patterns. Patterns become wisdom.
 
-An 8-stage consolidation pipeline turns raw observations into structured knowledge — facts, relationships, causal links, goal tracking, failure patterns, hypothesis verification, and confidence decay. Each stage only processes new data since the last run.
+A 9-stage consolidation pipeline turns raw observations into structured knowledge — facts, relationships, causal links, patterns, contradictions, goal tracking, failure patterns, and hypothesis verification. Each stage only processes new data since the last run.
 
 ## Learn More
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -78,6 +78,8 @@ If tools fail, check `.env`:
 | `STASH_EMBEDDING_MODEL` | Must match `STASH_VECTOR_DIM` (1536 for `text-embedding-3-small`) |
 | `STASH_REASONER_MODEL` | Model used during consolidation |
 
+**Running fully local?** See [LOCAL_OLLAMA.md](LOCAL_OLLAMA.md) — Ollama on the host, no cloud API key.
+
 ## Troubleshooting
 
 **MCP client can't connect**

--- a/docs/LOCAL_OLLAMA.md
+++ b/docs/LOCAL_OLLAMA.md
@@ -1,0 +1,104 @@
+# Local setup with Ollama (no cloud API)
+
+Stash's landing page promises fully local, fully private memory. This guide closes the gap between marketing and `.env` — **Ollama on your machine, Stash in Docker, zero outbound API keys.**
+
+Contributed by [Sean Campbell](https://github.com/rudi193-cmd) · tested on Linux with Docker Compose.
+
+---
+
+## What you need
+
+- [Ollama](https://ollama.com) running on the **host** (not inside the Stash container)
+- Docker Compose (Stash's default install path)
+- ~2 GB disk for models + Postgres volume
+
+Pull models **before** `docker compose up`:
+
+```bash
+ollama pull nomic-embed-text
+ollama pull qwen2.5:3b
+```
+
+| Role | Model | Why |
+|------|-------|-----|
+| Embeddings | `nomic-embed-text` | 768-dim vectors; matches `STASH_VECTOR_DIM=768` |
+| Reasoner | `qwen2.5:3b` (or `llama3.2:3b`) | Consolidation synthesis; small models work for dev |
+
+---
+
+## Configure `.env`
+
+Copy `.env.example` → `.env` and use the **Ollama block** below.
+
+Stash runs in Docker; Ollama runs on the host. From inside the container, reach the host API at:
+
+- **Linux:** `http://host.docker.internal:11434/v1` (Docker 20.10+) or your bridge IP, e.g. `http://172.17.0.1:11434/v1`
+- **macOS / Windows Docker Desktop:** `http://host.docker.internal:11434/v1`
+
+```bash
+# --- Ollama (fully local) ---
+STASH_OPENAI_API_KEY=ollama          # required field; Ollama ignores the value
+STASH_OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+STASH_EMBEDDING_MODEL=nomic-embed-text
+STASH_REASONER_MODEL=qwen2.5:3b
+STASH_VECTOR_DIM=768                 # ⚠ set once before first run — cannot change later
+```
+
+> **Warning:** `STASH_VECTOR_DIM` locks at first init. If you already started Stash with `1536`, reset the Postgres volume or use a fresh database before switching to Ollama embeddings.
+
+---
+
+## Launch
+
+```bash
+docker compose up --build
+```
+
+Verify:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/sse
+docker compose logs stash | tail -20
+```
+
+Then follow [Getting Started](GETTING_STARTED.md): connect MCP → `init` → `remember` → `recall` → `consolidate`.
+
+---
+
+## Troubleshooting
+
+**`connection refused` to Ollama**
+
+- Confirm Ollama is listening: `curl http://localhost:11434/api/tags`
+- On Linux, if `host.docker.internal` fails, add to `docker-compose.yml` under `stash`:
+
+```yaml
+extra_hosts:
+  - "host.docker.internal:host-gateway"
+```
+
+**Empty recall / embedding errors**
+
+- Model names must match `ollama list` exactly
+- `STASH_VECTOR_DIM` must match the embedding model (768 for `nomic-embed-text`)
+
+**Consolidation slow or noisy**
+
+- Smaller reasoners (`qwen2.5:3b`, `llama3.2:3b`) are fine for dev; use a larger model only if synthesis quality matters
+
+---
+
+## OpenRouter vs Ollama
+
+| | Ollama (this guide) | OpenRouter / cloud |
+|---|---------------------|-------------------|
+| API key | Not required | Required |
+| Privacy | Stays on your LAN | Leaves your network |
+| Setup | Host Ollama + Docker bridge | `.env` API key only |
+| Best for | Local dev, air-gapped, Willow-style fleets | Quick eval, largest models |
+
+Both paths use the same MCP tools — Stash is model-agnostic by design.
+
+---
+
+*Questions or fixes:* open an issue on [alash3al/stash](https://github.com/alash3al/stash/issues).

--- a/docs/index.html
+++ b/docs/index.html
@@ -1698,7 +1698,7 @@
       <div class="stat-label">MCP tools</div>
     </div>
     <div class="stat-item">
-      <div class="stat-number">6</div>
+      <div class="stat-number">9</div>
       <div class="stat-label">Pipeline stages</div>
     </div>
     <div class="stat-item">


### PR DESCRIPTION
## Summary

- Adds **`docs/LOCAL_OLLAMA.md`** — fully local Stash setup (host Ollama + Docker Compose, no cloud API key). The landing page already sells this path; GETTING_STARTED was OpenRouter/API-key centric.
- Links the new guide from README and GETTING_STARTED.
- Adds commented Ollama vars to `.env.example`.
- Aligns README + docs site hero with the **9-stage** consolidation pipeline (landing diagram already shows 9; README said 8, hero said 6).

Follow-up to merged #8 (Getting Started + MCP copy buttons).

## Why this PR

Closes the gap between “fully private, fully offline” marketing and copy-paste setup for operators who run Ollama locally (same audience as local-first agent stacks).

## Test plan

- [ ] Copy `.env.example` Ollama block → `.env`, pull `nomic-embed-text` + `qwen2.5:3b`
- [ ] `docker compose up` with `extra_hosts: host-gateway` on Linux if needed
- [ ] MCP `init` → `remember` → `recall` over `http://localhost:8080/sse`
- [ ] Spot-check README / landing hero both say 9 pipeline stages

Contributed by @rudi193-cmd (also active on [Emerging-Rule/community](https://github.com/Emerging-Rule/community) lesson PRs).


Made with [Cursor](https://cursor.com)