### PR TITLE
fix(security): escape LIKE wildcards in namespace path resolution

### DIFF
--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -146,6 +146,19 @@ func splitPath(path string) []string {
 	return strings.Split(path, "/")
 }
 
+// escapeLikePattern escapes PostgreSQL LIKE meta-characters so the input
+// is matched as a literal. Use with `ESCAPE '\'` in the query.
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+func escapeLikePattern(s string) string {
+	return likeEscaper.Replace(s)
+}
+
+// likePatternForDescendants builds a LIKE prefix for slug descendant lookup.
+func likePatternForDescendants(path string) string {
+	return escapeLikePattern(path) + "/%"
+}
+
 // resolveNamespaceID returns the namespace ID for an exact path.
 // Returns ErrNamespaceNotFound if no matching namespace exists.
 func (b *Brain) resolveNamespaceID(ctx context.Context, path string) (int64, error) {
@@ -216,9 +229,12 @@ func (b *Brain) resolveNamespaceIDWithDescendants(ctx context.Context, path stri
 		return ids, rows.Err()
 	}
 
+	// Slug segments allow `_` (see pathSegmentRe), which is a LIKE wildcard
+	// in PostgreSQL. Escape it so `/foo_bar` only matches its own descendants,
+	// not `/fooXbar/...` for any X.
 	rows, err := b.pool.Query(ctx,
-		"SELECT id FROM namespaces WHERE slug = $1 OR slug LIKE $2",
-		path, path+"/%",
+		`SELECT id FROM namespaces WHERE slug = $1 OR slug LIKE $2 ESCAPE '\'`,
+		path, likePatternForDescendants(path),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("resolve namespace descendants: %w", err)

--- a/internal/brain/brain_test.go
+++ b/internal/brain/brain_test.go
@@ -1,0 +1,29 @@
+package brain
+
+import "testing"
+
+func TestEscapeLikePattern(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"/foo_bar", `/foo\_bar`},
+		{"/foo/bar", `/foo/bar`},
+		{"/100%", `/100\%`},
+		{`/a\b`, `/a\\b`},
+		{"/foo_bar/baz_qux", `/foo\_bar/baz\_qux`},
+	}
+	for _, tt := range tests {
+		if got := escapeLikePattern(tt.in); got != tt.want {
+			t.Errorf("escapeLikePattern(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestLikePatternForDescendants(t *testing.T) {
+	got := likePatternForDescendants("/foo_bar")
+	want := `/foo\_bar/%`
+	if got != want {
+		t.Errorf("likePatternForDescendants(/foo_bar) = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Revives and extends closed PR #5.

Namespace slugs allow `_` in path segments, but PostgreSQL `LIKE` treats `_` as a single-character wildcard. The descendant lookup in `resolveNamespaceIDWithDescendants` used `slug LIKE $path || '/%'` without escaping, so a path like `/foo_bar` could match `/fooXbar/...` and pull in unrelated namespace IDs — affecting recall, consolidate, goals, facts, and any API that resolves namespace descendants.

This PR:
- Adds `escapeLikePattern()` and uses `LIKE ... ESCAPE '\'` on the descendant query
- Adds `internal/brain/brain_test.go` — first unit tests in the repo — covering underscore, percent, and backslash escaping

## Test plan

- [x] `go test ./internal/brain/ -v` (escape + descendant pattern helpers)
- [ ] Manual: create namespaces `/foo_bar` and `/fooXbar/baz`; query descendants of `/foo_bar` — should not include `/fooXbar/baz`

Related: docs PR #9 remains open separately (Ollama setup).

Made with [Cursor](https://cursor.com)