### PR TITLE
docs(atlascloud): document Atlas Cloud setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,13 @@ STASH_MAX_RESULT_SIZE=10000
 STASH_OPENAI_API_KEY=your-openai-api-key-here
 STASH_OPENAI_BASE_URL=https://api.openai.com/v1
 
+# Atlas Cloud example:
+# STASH_OPENAI_API_KEY=your-atlas-cloud-api-key
+# STASH_OPENAI_BASE_URL=https://api.atlascloud.ai/v1
+# STASH_EMBEDDING_MODEL=text-embedding-3-small
+# STASH_REASONER_MODEL=deepseek-ai/DeepSeek-V3-0324
+# STASH_VECTOR_DIM=1536
+
 # Embedding model (required)
 # OpenAI: text-embedding-3-small, text-embedding-3-large
 # OpenRouter: openai/text-embedding-3-small

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Every LLM starts every conversation from zero. Stash gives your agent persistent
 
 Open source. Self-hosted. Works with any MCP-compatible agent.
 
+Stash also works with OpenAI-compatible providers such as OpenAI, OpenRouter, [Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=stash), local Ollama, and other compatible gateways.
+
 ## Quick Start
 
 ```bash
@@ -20,6 +22,30 @@ That's it. Postgres + pgvector, migrations, MCP server with background consolida
 **Next:** [Getting Started guide](docs/GETTING_STARTED.md) — connect your MCP client, run `init` / `remember` / `recall`, and verify everything works.
 
 **Fully local (no cloud API):** [Ollama setup guide](docs/LOCAL_OLLAMA.md) — host Ollama + Docker Compose, private embeddings and reasoner.
+
+## Atlas Cloud
+
+> [Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=stash) is a full-modal AI inference platform that gives developers a single AI API to access video generation, image generation, and LLM APIs. Instead of managing multiple vendor integrations, you connect once and get unified access to 300+ curated models across all modalities.
+>
+> Check out Atlas Cloud's coding plan promotion: [https://www.atlascloud.ai/console/coding-plan](https://www.atlascloud.ai/console/coding-plan)
+
+Stash already supports Atlas Cloud through its OpenAI-compatible API. Set your `.env` like this:
+
+```bash
+STASH_OPENAI_API_KEY=your-atlas-cloud-api-key
+STASH_OPENAI_BASE_URL=https://api.atlascloud.ai/v1
+STASH_EMBEDDING_MODEL=text-embedding-3-small
+STASH_REASONER_MODEL=deepseek-ai/DeepSeek-V3-0324
+STASH_VECTOR_DIM=1536
+```
+
+Atlas Cloud works well here because Stash only needs:
+
+- an embeddings model for vectorization
+- a chat-capable reasoning model for consolidation
+- an OpenAI-compatible base URL and API key
+
+See [Getting Started](docs/GETTING_STARTED.md) for a fuller configuration checklist.
 
 ## MCP Client Setup
 
@@ -77,7 +103,7 @@ Point any MCP-compatible client at that URL. Example configs:
 }
 ```
 
-Works with any agent that supports MCP over SSE — Claude Desktop, Cursor, Windsurf, Cline, Continue, OpenAI Agents, Ollama, OpenRouter, and more.
+Works with any agent that supports MCP over SSE — Claude Desktop, Cursor, Windsurf, Cline, Continue, OpenAI Agents, Ollama, OpenRouter, Atlas Cloud-backed setups, and more.
 
 ## What It Does
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -80,6 +80,18 @@ If tools fail, check `.env`:
 
 **Running fully local?** See [LOCAL_OLLAMA.md](LOCAL_OLLAMA.md) — Ollama on the host, no cloud API key.
 
+**Using Atlas Cloud?** Stash already supports it through the OpenAI-compatible API:
+
+```bash
+STASH_OPENAI_API_KEY=your-atlas-cloud-api-key
+STASH_OPENAI_BASE_URL=https://api.atlascloud.ai/v1
+STASH_EMBEDDING_MODEL=text-embedding-3-small
+STASH_REASONER_MODEL=deepseek-ai/DeepSeek-V3-0324
+STASH_VECTOR_DIM=1536
+```
+
+Atlas Cloud docs: [https://www.atlascloud.ai/docs](https://www.atlascloud.ai/docs)
+
 ## Troubleshooting
 
 **MCP client can't connect**
@@ -96,6 +108,12 @@ If tools fail, check `.env`:
 
 - Needs episodes via `remember` first.
 - Check logs: `docker compose logs stash`.
+
+**Provider returns auth or model errors**
+
+- Confirm `STASH_OPENAI_BASE_URL` points to the correct provider endpoint.
+- Confirm the embedding and reasoner model names match what your provider exposes.
+- Atlas Cloud users should use `https://api.atlascloud.ai/v1` and a valid API key.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- document Atlas Cloud as a supported OpenAI-compatible provider for Stash
- add Atlas Cloud configuration examples to README and getting started docs
- extend `.env.example` with a commented Atlas Cloud setup snippet

## Why This PR
Stash already works with OpenAI-compatible APIs, so Atlas Cloud support is available without runtime changes. This PR makes that workflow explicit for users and keeps the documentation aligned with the existing configuration model.

## Validation
- README / docs updated
- targeted diagnostics checked
- `go test ./...` could not run in this environment because the `go` binary is unavailable