### PR TITLE
docs: clarify that curl /sse holding open is expected SSE behavior (#11)

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -94,6 +94,23 @@ Atlas Cloud docs: [https://www.atlascloud.ai/docs](https://www.atlascloud.ai/doc
 
 ## Troubleshooting
 
+**`curl /sse` prints an `event: endpoint` line, then appears to hang**
+
+This is expected — the server is healthy, not stuck. `/sse` is a long-lived
+[Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
+stream: it emits the initial `endpoint` event (the `/message?sessionId=...` URL the
+client posts back to) and then holds the connection open for the MCP session. A raw
+`curl` can't complete the MCP handshake, so it just waits.
+
+- To check the server is up *without* holding the stream open, request the status code only:
+
+  ```bash
+  curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/sse   # expect 200
+  ```
+
+- For a real end-to-end check, connect an MCP client (see [Connect your MCP client](#2-connect-your-mcp-client))
+  and confirm Stash appears in its tool list.
+
 **MCP client can't connect**
 
 - Confirm `docker compose up` finished and port 8080 is not in use elsewhere.


### PR DESCRIPTION
## What

Adds a Troubleshooting entry to `docs/GETTING_STARTED.md` explaining that a raw `curl http://localhost:8080/sse` printing an `event: endpoint` line and then holding the connection open is **expected SSE behavior, not a hang**.

## Why

This is the exact confusion reported in #11 — a new user followed the Getting Started guide, tested with `curl`, saw the stream hold open, and read it as the server hanging. As you noted there, `curl` can't complete the MCP handshake. There was no note in the docs explaining that the hold-open is normal, so the next newcomer hits the same wall.

The entry:
- explains the `/sse` stream emits the initial `endpoint` event then stays open for the MCP session;
- shows the non-blocking status-code check (`curl -s -o /dev/null -w "%{http_code}"`) already used in §1;
- points to the existing "Connect your MCP client" section for a real end-to-end check.

## Scope

Docs-only, +17 lines, no behavior change. Placed first in Troubleshooting since it's the most common first-run gotcha. Independent of #13 (which only adjusts CLI help text).

Closes #11.